### PR TITLE
カバレッジ改善

### DIFF
--- a/filterweb/_cli.py
+++ b/filterweb/_cli.py
@@ -2,6 +2,7 @@ import functools
 from typing import Optional
 import click
 import yaml
+from ._version import VERSION
 
 
 def set_verbose(verbose: Optional[bool]):
@@ -31,7 +32,7 @@ def config_arg(func):
     return click.argument("config", type=click.File("r"))(wrap)
 
 
-@click.version_option(version="0.1", prog_name="filterweb")
+@click.version_option(version=VERSION, prog_name="filterweb")
 @click.group(invoke_without_command=True)
 @click.pass_context
 def cli(ctx):

--- a/filterweb/input/ssh.py
+++ b/filterweb/input/ssh.py
@@ -3,6 +3,9 @@ from typing import Optional
 import paramiko
 from pydantic.dataclasses import dataclass
 from dataclasses import field
+from logging import getLogger
+
+_log = getLogger(__name__)
 
 
 @input_arg
@@ -39,8 +42,14 @@ class InputSSH(InputBase):
             timeout=self.config.timeout)
         if self.config.input:
             stdin.write(self.config.input)
+        exit_code = stdout.channel.recv_exit_status()
+        if exit_code != 0:
+            _log.info("exit code: %s", exit_code)
         stdin.close()
         res = stdout.read()
         client.close()
+        err_str = stderr.read()
+        if err_str:
+            _log.info("stderr: %s", err_str)
         del stdin, stdout, stderr, client
         return res

--- a/filterweb/serve/flask.py
+++ b/filterweb/serve/flask.py
@@ -62,6 +62,6 @@ class ServeFlask(ServeBase):
         if self.config.server == "builtin":
             self.server.shutdown()
         elif self.config.server == "waitress":
-            self.server.shutdown()
+            self.server.close()
         elif self.config.server == "gunicorn":
             raise NotImplementedError("gunicorn shutdown")

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -99,7 +99,7 @@ class TestServeFlask(TestServeHTTP):
 
 
 try:
-    import waitress
+    import waitress as _
     has_waitress = True
 except ImportError:
     has_waitress = False

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -26,6 +26,13 @@ class TestServeHTTP(unittest.TestCase):
                 "sources": [{
                     "name": "file",
                     "filename": self.tf.name,
+                }, {
+                    "name": "file",
+                    "filename": self.tf.name,
+                }, {
+                    "name": "file",
+                    "filename": self.tf.name,
+                    "merge": False,
                 }],
                 "filters": [{
                     "name": "jinja",
@@ -89,3 +96,24 @@ class TestServeFlask(TestServeHTTP):
         while not hasattr(self.srv, "server"):
             time.sleep(0.5)
         self.url = f"http://{self.srv.server.server_address[0]}:{self.srv.server.server_address[1]}/"
+
+
+try:
+    import waitress
+    has_waitress = True
+except ImportError:
+    has_waitress = False
+
+
+@unittest.skipUnless(hasattr(filterweb.serve, "ServeFlask") and has_waitress, "no flask/waitress installed")
+class TestServeFlaskWaitress(TestServeHTTP):
+    def boot(self, config):
+        config["server"] = "waitress"
+        self.srv = filterweb.open_serve("flask", config)
+        self.th = threading.Thread(target=self.srv.serve, name="flask-server")
+        self.th.start()
+        while not hasattr(self.srv, "server"):
+            time.sleep(0.5)
+        self.srv.server.print_listen("Serving on {}:{}")
+        efl = self.srv.server.effective_listen[-1]
+        self.url = f"http://{efl[0]}:{efl[1]}/"

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,3 +1,4 @@
+import importlib.util
 import unittest
 import tempfile
 import filterweb
@@ -98,11 +99,8 @@ class TestServeFlask(TestServeHTTP):
         self.url = f"http://{self.srv.server.server_address[0]}:{self.srv.server.server_address[1]}/"
 
 
-try:
-    import waitress as _
-    has_waitress = True
-except ImportError:
-    has_waitress = False
+waitress_spec = importlib.util.find_spec("waitress")
+has_waitress = waitress_spec is not None
 
 
 @unittest.skipUnless(hasattr(filterweb.serve, "ServeFlask") and has_waitress, "no flask/waitress installed")


### PR DESCRIPTION
before

```
---------- coverage: platform linux, python 3.11.4-final-0 -----------
Name                           Stmts   Miss Branch BrPart  Cover
----------------------------------------------------------------
filterweb/__init__.py              5      0      0      0   100%
filterweb/_cli.py                 58      6     52      3    92%
filterweb/_version.py              1      1      0      0     0%
filterweb/base.py                  9      1      2      1    82%
filterweb/filter/__init__.py       6      2      0      0    67%
filterweb/filter/filter.py         6      1      2      0    88%
filterweb/filter/jinja.py         34      4     14      2    83%
filterweb/filter/pygments.py      23      0      6      0   100%
filterweb/index.py                31      0     10      0   100%
filterweb/input/__init__.py       23      8      0      0    65%
filterweb/input/file.py           11      0      7      0   100%
filterweb/input/grpc.py           17      2      5      0    91%
filterweb/input/http.py           18      5      7      0    72%
filterweb/input/http_unix.py      18      4      5      0    83%
filterweb/input/input.py          62      1     27      0    99%
filterweb/input/jsonrpc.py        14      2      5      0    89%
filterweb/input/process.py        12      0      5      0   100%
filterweb/input/sftp.py           24      9      5      0    69%
filterweb/input/sqlite.py         23      1     11      1    94%
filterweb/input/ssh.py            31     11      7      0    66%
filterweb/input/xmlrpc.py         20      0      9      0   100%
filterweb/serve/__init__.py        6      2      0      0    67%
filterweb/serve/flask.py          51     11     20      2    70%
filterweb/serve/http.py           50      5     14      3    84%
filterweb/serve/serve.py          54     16     18      1    65%
----------------------------------------------------------------
TOTAL                            607     92    231     13    85%
```
